### PR TITLE
feature/add_login_form_and_login_with_discord

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,1 @@
+VITE_DRAWS_API_URL=http://localhost:5000

--- a/package.json
+++ b/package.json
@@ -11,10 +11,12 @@
   },
   "dependencies": {
     "axios": "^1.6.7",
+    "formik": "^2.4.5",
     "react": "^18.2.0",
     "react-daisyui": "^5.0.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.3",
+    "yup": "^1.4.0",
     "zustand": "^4.5.2"
   },
   "devDependencies": {

--- a/src/apis/drawsApi.ts
+++ b/src/apis/drawsApi.ts
@@ -1,0 +1,23 @@
+import axios from 'axios';
+import { environment } from '../global';
+import { useAuthStore } from '../stores';
+
+
+const drawsApi = axios.create({
+  baseURL: environment.DRAWS_API_URL
+});
+
+drawsApi.interceptors.request.use(
+  (config) => {
+    const token = useAuthStore.getState().token;
+    if(token) {
+      config.headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    return config;
+  }
+)
+
+export {
+  drawsApi
+}

--- a/src/global/environments.ts
+++ b/src/global/environments.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  DRAWS_API_URL: import.meta.env.VITE_DRAWS_API_URL
+}

--- a/src/global/index.ts
+++ b/src/global/index.ts
@@ -1,0 +1,2 @@
+export * from './urls';
+export * from './environments'

--- a/src/global/urls.ts
+++ b/src/global/urls.ts
@@ -1,0 +1,17 @@
+export enum PATHS {
+  ROOT = '',
+  HOME = 'home',
+  AUTH = 'auth',
+  LOGIN = 'login',
+  DASHBOARD = 'dashboard',
+  TEST = 'test',
+}
+
+export enum ROUTES {
+  ROOT = '/',
+  HOME = '/home',
+  LOGIN = '/auth/login',
+  DASHBOARD = '/dashboard',
+  TEST = '/test',
+
+}

--- a/src/interfaces/auth.interface.ts
+++ b/src/interfaces/auth.interface.ts
@@ -1,0 +1,24 @@
+export type AuthStatus = 'authorized' | 'unauthorized' | 'pending'; 
+
+export interface LoginResponse {
+  id: string;
+  email: string;
+  fullName: string;
+  isActive: boolean;
+  roles: string[];
+  token: string;
+}
+
+export interface DiscordLoginResponse {
+  id: string;
+  discordId: string;
+  username: string;
+  avatar: string;
+  discriminator: string;
+  globalName: string;
+  email: string;
+  token: string;
+  verified: boolean;
+  createdAt: string;
+  updatedAt: string;
+}

--- a/src/interfaces/auth.interface.ts
+++ b/src/interfaces/auth.interface.ts
@@ -1,24 +1,12 @@
+import { User, UserDiscord } from "./users.interface";
+
 export type AuthStatus = 'authorized' | 'unauthorized' | 'pending'; 
 
-export interface LoginResponse {
-  id: string;
-  email: string;
-  fullName: string;
-  isActive: boolean;
-  roles: string[];
+export interface AuthResponse {
+  user?: User | UserDiscord;
   token: string;
 }
 
-export interface DiscordLoginResponse {
-  id: string;
-  discordId: string;
-  username: string;
-  avatar: string;
-  discriminator: string;
-  globalName: string;
-  email: string;
-  token: string;
-  verified: boolean;
-  createdAt: string;
-  updatedAt: string;
+export interface DiscordUrl {
+  url: string;
 }

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,0 +1,1 @@
+export * from './auth.interface'

--- a/src/interfaces/users.interface.ts
+++ b/src/interfaces/users.interface.ts
@@ -1,0 +1,7 @@
+export interface User {
+
+}
+
+export interface DiscordUser {
+
+}

--- a/src/interfaces/users.interface.ts
+++ b/src/interfaces/users.interface.ts
@@ -1,7 +1,27 @@
 export interface User {
-
+  id: string;
+  username: string;
+  email: string;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
 }
 
-export interface DiscordUser {
-
+export interface UserDiscord {
+  id: string;
+  username: string;
+  avatar: string;
+  discriminator: string;
+  public_flags: number;
+  premium_type: number;
+  flags: number;
+  banner: null;
+  accent_color: null;
+  global_name: string;
+  avatar_decoration_data: null;
+  banner_color: null;
+  mfa_enabled: boolean;
+  locale: string;
+  email: string;
+  verified: boolean;
 }

--- a/src/router/PrivateRoute.tsx
+++ b/src/router/PrivateRoute.tsx
@@ -1,0 +1,18 @@
+import { FC } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuthStore } from '../stores';
+
+interface PrivateRouteProps {
+  children: JSX.Element;
+}
+
+export const PrivateRoute: FC<PrivateRouteProps> = ({ children }) => {
+  const { user } = useAuthStore.getState();
+  const location = useLocation();
+
+  if (user === null || undefined) {
+    return <Navigate to={`/auth/login`} state={{ from: location }} replace />;
+  }
+
+  return children;
+};

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,11 +1,15 @@
-import { createBrowserRouter } from 'react-router-dom';
-import { MiddlewarePage, RootPage, TestPage } from '../views/pages';
+import { Navigate, createBrowserRouter } from 'react-router-dom';
+import {
+  MiddlewarePage,
+  // RootPage,
+  TestPage
+} from '../views/pages';
 import { PATHS } from '../global';
 
 export const router = createBrowserRouter([
   {
     path: PATHS.ROOT,
-    element: <RootPage />,
+    element: <Navigate to={PATHS.TEST} />,
   },
   {
     path: PATHS.TEST,

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,9 +1,14 @@
 import { createBrowserRouter } from 'react-router-dom';
-import { RootPage } from '../views/pages';
+import { RootPage, TestPage } from '../views/pages';
+import { PATHS } from '../global';
 
 export const router = createBrowserRouter([
   {
-    path: "/",
+    path: PATHS.ROOT,
     element: <RootPage />,
+  },
+  {
+    path: PATHS.TEST,
+    element: <TestPage />,
   },
 ]);

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,5 +1,5 @@
 import { createBrowserRouter } from 'react-router-dom';
-import { RootPage, TestPage } from '../views/pages';
+import { MiddlewarePage, RootPage, TestPage } from '../views/pages';
 import { PATHS } from '../global';
 
 export const router = createBrowserRouter([
@@ -10,5 +10,13 @@ export const router = createBrowserRouter([
   {
     path: PATHS.TEST,
     element: <TestPage />,
+  },
+  {
+    path: PATHS.AUTH,
+    element: <MiddlewarePage />,
+  },
+  {
+    path: PATHS.DASHBOARD,
+    element: <>Dashboard</>,
   },
 ]);

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -47,7 +47,7 @@ export class AuthService {
   static checkDiscordAthStatus = async (code: string): Promise<AuthResponse> => {
     if (!code) throw new Error("Missing code");
     try {
-      const { data } = await drawsApi.get(`/auth/oauth-token?code=${code}`);
+      const { data } = await drawsApi.get<AuthResponse>(`/auth/oauth-token?code=${code}`);
       return data;
     } catch (error) {
       if (error instanceof AxiosError) {

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,13 +1,12 @@
 import { AxiosError } from "axios";
 import { drawsApi } from "../apis/drawsApi";
-import { DiscordLoginResponse, LoginResponse } from "../interfaces";
+import { AuthResponse, DiscordUrl } from "../interfaces";
 
 export class AuthService {
-  // ? Login with User Credentials (email & password) - Only for admins
-  static login = async (email: string, password: string): Promise<LoginResponse> => {
+  // ? Login with User Credentials (username & password) - Only for admins
+  static login = async (username: string, password: string): Promise<AuthResponse> => {
     try {
-      const { data } = await drawsApi.post<LoginResponse>('/auth/login', { email, password });
-      // console.log(data);
+      const { data } = await drawsApi.post<AuthResponse>('/auth/login', { username, password });
       return data;
     } catch (err) {
       if (err instanceof AxiosError) {
@@ -20,9 +19,9 @@ export class AuthService {
   }
 
   // ? Check the session status - Only for admins
-  static checkStatus = async (): Promise<LoginResponse> => {
+  static checkStatus = async (): Promise<AuthResponse> => {
     try {
-      const { data } = await drawsApi.get<LoginResponse>('/auth/check-status');
+      const { data } = await drawsApi.get<AuthResponse>('/auth/check-status');
       return data;
     } catch(error) {
       console.log(error);
@@ -31,35 +30,30 @@ export class AuthService {
   }
 
   // ? Login with Discord Button SignIn - Only for competitors
-  static loginWithDiscord = async (): Promise<DiscordLoginResponse> => {
+  static loginWithDiscord = async (): Promise<DiscordUrl> => {
     try {
-      const { data } = await drawsApi.post<DiscordLoginResponse>('/auth/oauth-url');
-      // console.log(data);
+      const { data } = await drawsApi.get<DiscordUrl>('/auth/oauth-url');
       return data;
     } catch (err) {
       if (err instanceof AxiosError) {
         console.log(err.response?.data);
         throw new Error(err.response?.data);
       }
-      console.log(err)
       throw new Error('Unable to login!')
     }
   }
 
   // ? Check the Discord Session - Only for competitos
-  static checkDiscordAthStatus = async (code: string): Promise<DiscordLoginResponse> => {
+  static checkDiscordAthStatus = async (code: string): Promise<AuthResponse> => {
     if (!code) throw new Error("Missing code");
     try {
-      const { data } = await drawsApi.post(`/auth/oauth-token?code=${code}`);
-      // console.log(data);
+      const { data } = await drawsApi.get(`/auth/oauth-token?code=${code}`);
       return data;
-
     } catch (error) {
       if (error instanceof AxiosError) {
         console.log(error.response?.data);
         throw new Error(error.response?.data);
       }
-      console.log(error);
       throw new Error("Unable to authenticate");
     }
   }

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,0 +1,66 @@
+import { AxiosError } from "axios";
+import { drawsApi } from "../apis/drawsApi";
+import { DiscordLoginResponse, LoginResponse } from "../interfaces";
+
+export class AuthService {
+  // ? Login with User Credentials (email & password) - Only for admins
+  static login = async (email: string, password: string): Promise<LoginResponse> => {
+    try {
+      const { data } = await drawsApi.post<LoginResponse>('/auth/login', { email, password });
+      // console.log(data);
+      return data;
+    } catch (err) {
+      if (err instanceof AxiosError) {
+        console.log(err.response?.data);
+        throw new Error(err.response?.data);
+      }
+      console.log(err)
+      throw new Error('Unable to login!')
+    }
+  }
+
+  // ? Check the session status - Only for admins
+  static checkStatus = async (): Promise<LoginResponse> => {
+    try {
+      const { data } = await drawsApi.get<LoginResponse>('/auth/check-status');
+      return data;
+    } catch(error) {
+      console.log(error);
+      throw new Error('Unauthorized');
+    }
+  }
+
+  // ? Login with Discord Button SignIn - Only for competitors
+  static loginWithDiscord = async (): Promise<DiscordLoginResponse> => {
+    try {
+      const { data } = await drawsApi.post<DiscordLoginResponse>('/auth/oauth-url');
+      // console.log(data);
+      return data;
+    } catch (err) {
+      if (err instanceof AxiosError) {
+        console.log(err.response?.data);
+        throw new Error(err.response?.data);
+      }
+      console.log(err)
+      throw new Error('Unable to login!')
+    }
+  }
+
+  // ? Check the Discord Session - Only for competitos
+  static checkDiscordAthStatus = async (code: string): Promise<DiscordLoginResponse> => {
+    if (!code) throw new Error("Missing code");
+    try {
+      const { data } = await drawsApi.post(`/auth/oauth-token?code=${code}`);
+      // console.log(data);
+      return data;
+
+    } catch (error) {
+      if (error instanceof AxiosError) {
+        console.log(error.response?.data);
+        throw new Error(error.response?.data);
+      }
+      console.log(error);
+      throw new Error("Unable to authenticate");
+    }
+  }
+}

--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -1,0 +1,73 @@
+import { StateCreator, create } from 'zustand';
+import { devtools, persist } from 'zustand/middleware';
+import { AuthService } from '../services/auth.service';
+import { DiscordUser, User } from '../interfaces/users.interface';
+
+export interface AuthState {
+  // authStatus: AuthStatus;
+  token?: string;
+  user?: User | DiscordUser;
+  loginUser: (email: string, password: string) => Promise<void>;
+  loginUserWithDiscord: () => Promise<void>;
+  checkAuthStatus: () => Promise<void>;
+  checkDiscordAuthStatus: (code: string) => Promise<void>;
+  logoutUser: () => void;
+}
+
+const storeAPI: StateCreator<AuthState> = (set) => ({
+  // authStatus: 'pending',
+  token: undefined,
+  user: undefined,
+  loginUser: async (email: string, password: string) => {
+    try {
+      const { token } = await AuthService.login(email, password);
+      set({  token });
+    } catch(error) {
+      set({ token: undefined });
+      throw 'Unauthorized';
+    }
+  },
+  loginUserWithDiscord: async () => {
+    try {
+      const { token } = await AuthService.loginWithDiscord();
+      set({  token });
+    } catch(error) {
+      set({ token: undefined });
+      throw 'Unauthorized';
+    }
+  },
+  checkDiscordAuthStatus: async (code: string): Promise<void> => {
+    try {
+      const { token, ...user } = await AuthService.checkDiscordAthStatus(code);
+      set({ token, user })
+      // set({ authStatus: 'authorized', token, user })
+
+    } catch (error) {
+      set({ user: undefined, token: undefined });
+      // set({ authStatus: 'unauthorized', user: undefined, token: undefined });
+    }
+  },
+  checkAuthStatus: async (): Promise<void> => {
+    try {
+      const { token, ...user } = await AuthService.checkStatus();
+      set({ token, user })
+      // set({ authStatus: 'authorized', token, user })
+    } catch (error) {
+      set({ user: undefined, token: undefined });
+      // set({ authStatus: 'unauthorized', user: undefined, token: undefined });
+    }
+  },
+  logoutUser: () => {
+    set({ user: undefined, token: undefined });
+    // set({ authStatus: 'unauthorized', user: undefined, token: undefined });
+  }
+});
+
+export const useAuthStore = create<AuthState>()((
+  devtools(
+    persist(
+      storeAPI,
+      { name: 'auth-store'}
+    )
+  )
+));

--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -6,18 +6,15 @@ import { User, UserDiscord } from '../interfaces/users.interface';
 export interface AuthState {
   token?: string;
   user?: User | UserDiscord;
-  url?: string,
   loginUser: (username: string, password: string) => Promise<void>;
-  loginUserWithDiscord: () => Promise<void>;
   checkAuthStatus: () => Promise<void>;
-  checkDiscordAuthStatus: (code: string) => Promise<void>;
+  setUserData: (token: string, user: User | UserDiscord) => void;
   logoutUser: () => void;
 }
 
 const storeAPI: StateCreator<AuthState> = (set) => ({
   token: undefined,
   user: undefined,
-  url: undefined,
   loginUser: async (username: string, password: string) => {
     try {
       const { token, user } = await AuthService.login(username, password);
@@ -25,23 +22,6 @@ const storeAPI: StateCreator<AuthState> = (set) => ({
     } catch(error) {
       set({ token: undefined });
       throw 'Unauthorized';
-    }
-  },
-  loginUserWithDiscord: async () => {
-    try {
-      const { url } = await AuthService.loginWithDiscord();
-      set({ url });
-    } catch(error) {
-      set({ url: undefined });
-      throw 'Unauthorized';
-    }
-  },
-  checkDiscordAuthStatus: async (code: string): Promise<void> => {
-    try {
-      const { token, user } = await AuthService.checkDiscordAthStatus(code);
-      set({ token, user })
-    } catch (error) {
-      set({ user: undefined, token: undefined });
     }
   },
   checkAuthStatus: async (): Promise<void> => {
@@ -52,8 +32,11 @@ const storeAPI: StateCreator<AuthState> = (set) => ({
       set({ user: undefined, token: undefined });
     }
   },
+  setUserData: (token: string, user: User | UserDiscord) => {
+    set({ token, user })
+  },
   logoutUser: () => {
-    set({ user: undefined, token: undefined, url: undefined });
+    set({ user: undefined, token: undefined });
   }
 });
 

--- a/src/stores/auth.store.ts
+++ b/src/stores/auth.store.ts
@@ -1,13 +1,13 @@
 import { StateCreator, create } from 'zustand';
 import { devtools, persist } from 'zustand/middleware';
 import { AuthService } from '../services/auth.service';
-import { DiscordUser, User } from '../interfaces/users.interface';
+import { User, UserDiscord } from '../interfaces/users.interface';
 
 export interface AuthState {
-  // authStatus: AuthStatus;
   token?: string;
-  user?: User | DiscordUser;
-  loginUser: (email: string, password: string) => Promise<void>;
+  user?: User | UserDiscord;
+  url?: string,
+  loginUser: (username: string, password: string) => Promise<void>;
   loginUserWithDiscord: () => Promise<void>;
   checkAuthStatus: () => Promise<void>;
   checkDiscordAuthStatus: (code: string) => Promise<void>;
@@ -15,13 +15,13 @@ export interface AuthState {
 }
 
 const storeAPI: StateCreator<AuthState> = (set) => ({
-  // authStatus: 'pending',
   token: undefined,
   user: undefined,
-  loginUser: async (email: string, password: string) => {
+  url: undefined,
+  loginUser: async (username: string, password: string) => {
     try {
-      const { token } = await AuthService.login(email, password);
-      set({  token });
+      const { token, user } = await AuthService.login(username, password);
+      set({ token, user });
     } catch(error) {
       set({ token: undefined });
       throw 'Unauthorized';
@@ -29,37 +29,31 @@ const storeAPI: StateCreator<AuthState> = (set) => ({
   },
   loginUserWithDiscord: async () => {
     try {
-      const { token } = await AuthService.loginWithDiscord();
-      set({  token });
+      const { url } = await AuthService.loginWithDiscord();
+      set({ url });
     } catch(error) {
-      set({ token: undefined });
+      set({ url: undefined });
       throw 'Unauthorized';
     }
   },
   checkDiscordAuthStatus: async (code: string): Promise<void> => {
     try {
-      const { token, ...user } = await AuthService.checkDiscordAthStatus(code);
+      const { token, user } = await AuthService.checkDiscordAthStatus(code);
       set({ token, user })
-      // set({ authStatus: 'authorized', token, user })
-
     } catch (error) {
       set({ user: undefined, token: undefined });
-      // set({ authStatus: 'unauthorized', user: undefined, token: undefined });
     }
   },
   checkAuthStatus: async (): Promise<void> => {
     try {
-      const { token, ...user } = await AuthService.checkStatus();
+      const { token, user } = await AuthService.checkStatus();
       set({ token, user })
-      // set({ authStatus: 'authorized', token, user })
     } catch (error) {
       set({ user: undefined, token: undefined });
-      // set({ authStatus: 'unauthorized', user: undefined, token: undefined });
     }
   },
   logoutUser: () => {
-    set({ user: undefined, token: undefined });
-    // set({ authStatus: 'unauthorized', user: undefined, token: undefined });
+    set({ user: undefined, token: undefined, url: undefined });
   }
 });
 

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,0 +1,1 @@
+export * from './auth.store'

--- a/src/views/pages/index.ts
+++ b/src/views/pages/index.ts
@@ -1,2 +1,3 @@
 export { default as RootPage } from './RootPage';
 export { default as TestPage } from './test/TestPage';
+export { default as MiddlewarePage } from './middleware/MiddlewarePage';

--- a/src/views/pages/index.ts
+++ b/src/views/pages/index.ts
@@ -1,1 +1,2 @@
 export { default as RootPage } from './RootPage';
+export { default as TestPage } from './test/TestPage';

--- a/src/views/pages/middleware/MiddlewarePage.tsx
+++ b/src/views/pages/middleware/MiddlewarePage.tsx
@@ -1,0 +1,37 @@
+import { FC, useCallback, useEffect } from 'react';
+import { useAuthStore } from '../../../stores';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+
+const MiddlewarePage: FC = () => {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const checkDiscordAuthStatus = useAuthStore((state) => state.checkDiscordAuthStatus);
+  const token = useAuthStore((state) => state.token);
+  const user = useAuthStore((state) => state.user);
+
+  const getUserToken = useCallback(async (code: string) => {
+    try {
+      await checkDiscordAuthStatus(code);
+      if (!token && !user) {
+        throw new Error('Unable to authenticate');
+      }
+      navigate('/dashboard', { replace: true });
+    }
+    catch (error) {
+      console.log(error);
+      navigate('/test', { replace: true });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const authCode = searchParams.get('code');
+    getUserToken(authCode || '');
+  }, [getUserToken, searchParams]);
+
+  return (
+    <></>
+  );
+};
+
+export default MiddlewarePage;

--- a/src/views/pages/test/TestPage.tsx
+++ b/src/views/pages/test/TestPage.tsx
@@ -1,0 +1,92 @@
+import { FC } from 'react';
+import { useNavigate } from 'react-router';
+import { Button, Input } from 'react-daisyui';
+import { Formik } from 'formik';
+import { LOGIN_INITIAL_VALUES, LOGIN_VALIDATION_SCHEMA, LoginFormValues } from './validations';
+import { useAuthStore } from '../../../stores';
+
+
+const TestPage: FC = () => {
+  const navigate = useNavigate();
+  const loginUser = useAuthStore((state) => state.loginUser);
+  const loginUserWithDiscord = useAuthStore((state) => state.loginUserWithDiscord);
+
+  const handleSubmit = async (values: LoginFormValues) => {
+    const { email, password } = values;
+    try {
+      await loginUser(email, password);
+      navigate('dashboard');
+    }
+    catch (err) {
+      console.log('No se pudo autenticar', err)
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-screen-xl px-4 sm:px-6 lg:px-8">
+      <div className="mx-auto max-w-lg my-auto">
+        <Formik
+          initialValues={LOGIN_INITIAL_VALUES}
+          // validateOnChange={false}
+          validationSchema={LOGIN_VALIDATION_SCHEMA}
+          enableReinitialize
+          onSubmit={(values) => handleSubmit(values)}
+        >
+          {({
+            values,
+            // errors,
+            handleChange,
+            handleSubmit,
+          }) => (
+            <form onSubmit={handleSubmit} className="mb-0 mt-6 space-y-4 rounded-lg p-4 shadow-lg sm:p-6 lg:p-8">
+              <p className="text-center text-lg font-medium">Login</p>
+              <div>
+                <label htmlFor="email" className="sr-only">Email</label>
+                <div className="relative">
+                  <Input
+                    type="email"
+                    placeholder="E-mail"
+                    id="email"
+                    name="email"
+                    className="w-full"
+                    value={values.email}
+                    onChange={handleChange}
+                  />
+                </div>
+              </div>
+
+              <div>
+                <label htmlFor="password" className="sr-only">Password</label>
+                <div className="relative">
+                  <Input
+                    type="password"
+                    placeholder="Password"
+                    id="password"
+                    name="password"
+                    className="w-full"
+                    value={values.password}
+                    onChange={handleChange}
+                  />
+                </div>
+              </div>
+
+              <Button type="submit" className="w-full">
+                Log In
+              </Button>
+              <Button className="w-full" onClick={loginUserWithDiscord}>
+                Log In with Discord
+              </Button>
+
+              <p className="text-center text-sm text-gray-500">
+                No account?
+                <a className="underline" href="#">Sign up</a>
+              </p>
+            </form>
+          )}
+        </Formik>
+      </div>
+    </div>
+  );
+};
+
+export default TestPage;

--- a/src/views/pages/test/TestPage.tsx
+++ b/src/views/pages/test/TestPage.tsx
@@ -4,13 +4,12 @@ import { Button, Input } from 'react-daisyui';
 import { Formik } from 'formik';
 import { LOGIN_INITIAL_VALUES, LOGIN_VALIDATION_SCHEMA, LoginFormValues } from './validations';
 import { useAuthStore } from '../../../stores';
+import { AuthService } from '../../../services/auth.service';
 
 
 const TestPage: FC = () => {
   const navigate = useNavigate();
   const loginUser = useAuthStore((state) => state.loginUser);
-  const loginUserWithDiscord = useAuthStore((state) => state.loginUserWithDiscord);
-  const url = useAuthStore((state) => state.url);
 
   const handleSubmit = async (values: LoginFormValues) => {
     const { username, password } = values;
@@ -25,7 +24,7 @@ const TestPage: FC = () => {
 
   const handleLoginWithDiscord = async () => {
     try {
-      await loginUserWithDiscord();
+      const { url } = await AuthService.loginWithDiscord();
       if (url) window.location.assign(url);
     }
     catch (err) {

--- a/src/views/pages/test/TestPage.tsx
+++ b/src/views/pages/test/TestPage.tsx
@@ -10,12 +10,23 @@ const TestPage: FC = () => {
   const navigate = useNavigate();
   const loginUser = useAuthStore((state) => state.loginUser);
   const loginUserWithDiscord = useAuthStore((state) => state.loginUserWithDiscord);
+  const url = useAuthStore((state) => state.url);
 
   const handleSubmit = async (values: LoginFormValues) => {
-    const { email, password } = values;
+    const { username, password } = values;
     try {
-      await loginUser(email, password);
-      navigate('dashboard');
+      await loginUser(username, password);
+      navigate('/dashboard');
+    }
+    catch (err) {
+      console.log('No se pudo autenticar', err)
+    }
+  }
+
+  const handleLoginWithDiscord = async () => {
+    try {
+      await loginUserWithDiscord();
+      if (url) window.location.assign(url);
     }
     catch (err) {
       console.log('No se pudo autenticar', err)
@@ -27,7 +38,6 @@ const TestPage: FC = () => {
       <div className="mx-auto max-w-lg my-auto">
         <Formik
           initialValues={LOGIN_INITIAL_VALUES}
-          // validateOnChange={false}
           validationSchema={LOGIN_VALIDATION_SCHEMA}
           enableReinitialize
           onSubmit={(values) => handleSubmit(values)}
@@ -44,12 +54,12 @@ const TestPage: FC = () => {
                 <label htmlFor="email" className="sr-only">Email</label>
                 <div className="relative">
                   <Input
-                    type="email"
-                    placeholder="E-mail"
-                    id="email"
-                    name="email"
+                    type="text"
+                    placeholder="Username"
+                    id="username"
+                    name="username"
                     className="w-full"
-                    value={values.email}
+                    value={values.username}
                     onChange={handleChange}
                   />
                 </div>
@@ -73,7 +83,7 @@ const TestPage: FC = () => {
               <Button type="submit" className="w-full">
                 Log In
               </Button>
-              <Button className="w-full" onClick={loginUserWithDiscord}>
+              <Button type="button" className="w-full" onClick={handleLoginWithDiscord}>
                 Log In with Discord
               </Button>
 

--- a/src/views/pages/test/validations.ts
+++ b/src/views/pages/test/validations.ts
@@ -1,0 +1,16 @@
+import * as Yup from 'yup';
+
+export interface LoginFormValues {
+  email: string;
+  password: string;
+}
+
+export const LOGIN_INITIAL_VALUES: LoginFormValues = {
+  email: '',
+  password: '',
+}
+
+export const LOGIN_VALIDATION_SCHEMA = Yup.object().shape({
+  email: Yup.string().email('Correo electrónico incorrecto').required('Requerido'),
+  password: Yup.string().required('Requerido'),
+});

--- a/src/views/pages/test/validations.ts
+++ b/src/views/pages/test/validations.ts
@@ -1,16 +1,16 @@
 import * as Yup from 'yup';
 
 export interface LoginFormValues {
-  email: string;
+  username: string;
   password: string;
 }
 
 export const LOGIN_INITIAL_VALUES: LoginFormValues = {
-  email: '',
+  username: '',
   password: '',
 }
 
 export const LOGIN_VALIDATION_SCHEMA = Yup.object().shape({
-  email: Yup.string().email('Correo electrónico incorrecto').required('Requerido'),
+  username: Yup.string().required('Requerido'),
   password: Yup.string().required('Requerido'),
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -402,6 +402,14 @@
   resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz"
   integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
 
+"@types/hoist-non-react-statics@^3.3.1":
+  version "3.3.5"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz#dab7867ef789d87e2b4b0003c9d65c49cc44a494"
+  integrity sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
+
 "@types/json-schema@^7.0.12":
   version "7.0.15"
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz"
@@ -795,6 +803,11 @@ deep-is@^0.1.3:
   resolved "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
+deepmerge@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
+  integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
+
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
@@ -1079,6 +1092,20 @@ form-data@^4.0.0:
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
 
+formik@^2.4.5:
+  version "2.4.5"
+  resolved "https://registry.yarnpkg.com/formik/-/formik-2.4.5.tgz#f899b5b7a6f103a8fabb679823e8fafc7e0ee1b4"
+  integrity sha512-Gxlht0TD3vVdzMDHwkiNZqJ7Mvg77xQNfmBRrNtvzcHZs72TJppSTDKHpImCMJZwcWPBJ8jSQQ95GJzXFf1nAQ==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.1"
+    deepmerge "^2.1.1"
+    hoist-non-react-statics "^3.3.0"
+    lodash "^4.17.21"
+    lodash-es "^4.17.21"
+    react-fast-compare "^2.0.1"
+    tiny-warning "^1.0.2"
+    tslib "^2.0.0"
+
 fraction.js@^4.3.7:
   version "4.3.7"
   resolved "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz"
@@ -1171,6 +1198,13 @@ hasown@^2.0.0:
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
   dependencies:
     function-bind "^1.1.2"
+
+hoist-non-react-statics@^3.3.0:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
 
 ignore@^5.2.0, ignore@^5.2.4:
   version "5.3.1"
@@ -1327,10 +1361,20 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash-es@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
+
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 loose-envify@^1.1.0:
   version "1.4.0"
@@ -1595,6 +1639,11 @@ prelude-ls@^1.2.1:
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
+property-expr@^2.0.5:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.6.tgz#f77bc00d5928a6c748414ad12882e83f24aec1e8"
+  integrity sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==
+
 proxy-from-env@^1.1.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz"
@@ -1622,6 +1671,16 @@ react-dom@^18.2.0:
   dependencies:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
+
+react-fast-compare@^2.0.1:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
+  integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
+
+react-is@^16.7.0:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
 react-router-dom@^6.22.3:
   version "6.22.3"
@@ -1865,12 +1924,27 @@ thenify-all@^1.0.0:
   dependencies:
     any-promise "^1.0.0"
 
+tiny-case@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-case/-/tiny-case-1.0.3.tgz#d980d66bc72b5d5a9ca86fb7c9ffdb9c898ddd03"
+  integrity sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==
+
+tiny-warning@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
+  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
+
 to-regex-range@^5.0.1:
   version "5.0.1"
   resolved "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz"
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
+
+toposort@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
+  integrity sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==
 
 ts-api-utils@^1.0.1:
   version "1.3.0"
@@ -1881,6 +1955,11 @@ ts-interface-checker@^0.1.9:
   version "0.1.13"
   resolved "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz"
   integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
+
+tslib@^2.0.0:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
+  integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
@@ -1893,6 +1972,11 @@ type-fest@^0.20.2:
   version "0.20.2"
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+
+type-fest@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-2.19.0.tgz#88068015bb33036a598b952e55e9311a60fd3a9b"
+  integrity sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==
 
 typescript@^5.2.2:
   version "5.4.2"
@@ -1979,6 +2063,16 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+yup@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-1.4.0.tgz#898dcd660f9fb97c41f181839d3d65c3ee15a43e"
+  integrity sha512-wPbgkJRCqIf+OHyiTBQoJiP5PFuAXaWiJK6AmYkzQAh5/c2K9hzSApBZG5wV9KoKSePF7sAxmNSvh/13YHkFDg==
+  dependencies:
+    property-expr "^2.0.5"
+    tiny-case "^1.0.3"
+    toposort "^2.0.2"
+    type-fest "^2.19.0"
 
 zustand@^4.5.2:
   version "4.5.2"


### PR DESCRIPTION
# feature/add_login_form_and_login_with_discord - Agregar formulario de inicio de sesión y login con Discord

### Hecho:

- Crear pagina y ruta de prueba para manejar los inicios de sesión.
- Crear enums de `ROUTES` y `PATHS` para manejo de rutas del enrutador.
- Definir `auth store` para manejo de data global de la autenticación (datos de usuario y token de autenticación).
- Definir instancia de axios `drawsApi` con inteceptor con cabeceras para realizar llamadas a la a API.
- Crear clase servicio `AuthService` para manejo de autenticación y llamadas a API.
- Crear constantes globales para facilitar el accesos a algunos valores que no varían en la app.
- Crear interfaz `AuthResponse` para manejar los datos del usuario autenticado. 
- Crear componente `MiddlewarePage` para controlar el inicio de sesión de Discord y las redirecciones a las paginas dependiendo del estado de la autenticación.
- Agregar estado inicial y validaciones al formulario de inicio de sesión con `Formik` y `Yup`.
