### PR TITLE
PR discord users dashboard

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useGetDraws } from "./useGetDraws";

--- a/src/hooks/useGetDraws.ts
+++ b/src/hooks/useGetDraws.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+import { DrawData } from "../interfaces";
+import { DrawsService } from "../services/draws.service";
+
+export function useGetDraws() {
+  const [isLoading, setIsLoading] = useState(true);
+  const [draws, setDraws] = useState<DrawData[]>([]);
+  const getDraws = async (page?: number, limit?: number) => {
+    setIsLoading(true);
+    try {
+      const { data } = await DrawsService.getDrawsList(page, limit);
+      setDraws(data);
+    } catch (error) {
+      setDraws([]);
+    }
+    setIsLoading(false);
+  };
+  useEffect(() => {
+    getDraws();
+  }, []);
+
+  return {
+    draws,
+    isLoading,
+    getDraws,
+  };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -11,3 +11,34 @@
   background-repeat: no-repeat;
   background-size: cover;
 }
+
+.skeleton-animation {
+  display: inline-block;
+  /* height: 1em; */
+  position: relative;
+  overflow: hidden;
+  /* background-color: #DDDBDD; */
+}
+.skeleton-animation::after {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  transform: translateX(-100%);
+  background-image: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0) 0,
+    rgba(255, 255, 255, 0.2) 20%,
+    rgba(255, 255, 255, 0.5) 60%,
+    rgba(255, 255, 255, 0)
+  );
+  animation: shimmer 5s infinite;
+  content: "";
+  /* @apply bg-skeleton-gradient; */
+}
+@keyframes shimmer {
+  100% {
+    transform: translateX(100%);
+  }
+}

--- a/src/interfaces/draws.interface.ts
+++ b/src/interfaces/draws.interface.ts
@@ -1,0 +1,23 @@
+import { ResponseWithPagination } from "./response-with-pagination.interface";
+import { UserDiscord } from "./users.interface";
+
+export type DrawStatus = "pending" | "live" | "finished" | "canceled";
+
+export interface DrawData {
+  id: string;
+  title: string;
+  description: string;
+  createdBy: string;
+  status: DrawStatus;
+  available: boolean;
+  maxParticipants: number | null;
+  numberOfWinners: number;
+  prizes: string[];
+  maxDateToJoin: string | null;
+  participants: string[] | UserDiscord[];
+  winners: string[] | UserDiscord[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type DrawsListResponse = ResponseWithPagination<DrawData>;

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,1 +1,4 @@
 export * from './auth.interface'
+
+export * from './response-with-pagination.interface';
+export * from './draws.interface';

--- a/src/interfaces/response-with-pagination.interface.ts
+++ b/src/interfaces/response-with-pagination.interface.ts
@@ -1,0 +1,5 @@
+export interface ResponseWithPagination<T> {
+  data: T[];
+  totalPages: number;
+  currentPage: number;
+}

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,11 +1,12 @@
 import { Navigate, createBrowserRouter } from 'react-router-dom';
 import {
   DashboardPage,
+  UserDashboardPage,
   LoginPage,
   MiddlewarePage,
 } from '../views/pages';
 import { PATHS, ROUTES } from '../global';
-import { AppLayout, AuthLayout } from '../views/layouts';
+import { AppLayout, AuthLayout, UserLayout } from '../views/layouts';
 
 export const router = createBrowserRouter([
   {
@@ -43,11 +44,11 @@ export const router = createBrowserRouter([
   },
   {
     path: PATHS.ROOT, 
-    element: <AppLayout />,
+    element: <UserLayout />,
     children: [
       {
         path: PATHS.DASHBOARD,
-        element: <DashboardPage />,
+        element: <UserDashboardPage />,
       },
     ]
   },

--- a/src/services/draws.service.ts
+++ b/src/services/draws.service.ts
@@ -1,0 +1,24 @@
+import { AxiosError } from "axios";
+import { drawsApi } from "../apis/drawsApi";
+import { DrawsListResponse } from "../interfaces";
+
+export class DrawsService {
+  static getDrawsList = async (
+    page?: number,
+    limit?: number
+  ): Promise<DrawsListResponse> => {
+    try {
+      const { data } = await drawsApi.get<DrawsListResponse>("/draws", {
+        params: { limit, page },
+      });
+      return data;
+    } catch (err) {
+      if (err instanceof AxiosError) {
+        console.log(err.response?.data);
+        throw new Error(err.response?.data);
+      }
+      console.log(err);
+      throw new Error("Unknown error");
+    }
+  };
+}

--- a/src/views/layouts/UserLayout.tsx
+++ b/src/views/layouts/UserLayout.tsx
@@ -1,0 +1,17 @@
+import { Outlet } from "react-router-dom";
+import DiscordUsersNav from "./components/DiscordUsersNav";
+
+const UserLayout: React.FC = () => {
+  return (
+    <div className="h-screen w-full bg-gray-200">
+      <div className="flex">
+        <DiscordUsersNav />
+        <div className="p-6 px-10 w-full">
+          <Outlet />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default UserLayout;

--- a/src/views/layouts/components/DiscordUsersNav.tsx
+++ b/src/views/layouts/components/DiscordUsersNav.tsx
@@ -1,0 +1,55 @@
+import { FC } from "react";
+import { Avatar, Divider, Dropdown, Tooltip } from "react-daisyui";
+import DevTallesLogo from "../../assets/ISO_MONO1.png";
+import { useAuthStore } from "../../../stores";
+import { useNavigate } from "react-router-dom";
+import { ROUTES } from "../../../global";
+
+const DiscordUsersNav: FC = () => {
+  const navigate = useNavigate();
+  const logoutUser = useAuthStore((state) => state.logoutUser);
+
+  const handleLogout = () => {
+    logoutUser();
+    navigate(`${ROUTES.LOGIN}`);
+  };
+
+  return (
+    <aside className="flex">
+      <div className="flex flex-col items-center justify-between w-16 h-screen py-8 space-y-8 bg-devtalles-600">
+        <div className="flex flex-col items-center space-y-4">
+          <a href="#">
+            <img className="w-auto h-10" src={DevTallesLogo} alt="" />
+          </a>
+          <Divider color="primary" />
+
+          <Tooltip position="right" message="Inicio">
+            <button
+              type="button"
+              className="p-1.5 text-[#A6A1FF] hover:bg-[#ffffff]/[.15] focus:active:bg-[#ffffff]/[.15] focus:outline-nones transition-colors duration-200 rounded-lg  "
+            >
+              <i className="bx bx-home-alt bx-sm"></i>
+            </button>
+          </Tooltip>
+        </div>
+
+        <Dropdown vertical="top" horizontal="right">
+          <Dropdown.Toggle button={false}>
+            <Avatar
+              className="cursor-pointer"
+              shape="circle"
+              src="https://daisyui.com/images/stock/photo-1534528741775-53994a69daeb.jpg"
+              online
+              size="xs"
+            />
+          </Dropdown.Toggle>
+          <Dropdown.Menu className="w-52">
+            <Dropdown.Item onClick={handleLogout}>LogOut</Dropdown.Item>
+          </Dropdown.Menu>
+        </Dropdown>
+      </div>
+    </aside>
+  );
+};
+
+export default DiscordUsersNav;

--- a/src/views/layouts/index.ts
+++ b/src/views/layouts/index.ts
@@ -1,2 +1,3 @@
 export { default as AuthLayout } from './AuthLayout';
 export { default as AppLayout } from './AppLayout';
+export { default as UserLayout } from './UserLayout';

--- a/src/views/pages/components/DateFormatter.tsx
+++ b/src/views/pages/components/DateFormatter.tsx
@@ -1,0 +1,12 @@
+interface Props {
+  date: string;
+}
+export function DateFormatter({ date }: Props) {
+  return (
+    <>
+      {new Intl.DateTimeFormat("es", { dateStyle: "medium" }).format(
+        new Date(date)
+      )}
+    </>
+  );
+}

--- a/src/views/pages/components/DrawCard.tsx
+++ b/src/views/pages/components/DrawCard.tsx
@@ -1,0 +1,50 @@
+import { Card } from "react-daisyui";
+import { DrawData, DrawStatus } from "../../../interfaces";
+import { DateFormatter } from ".";
+
+export function DrawCard(props: DrawData) {
+  return (
+    <article>
+      <Card className="shadow-md bg-white">
+        <Card.Body>
+          <Card.Title tag="h3" className="text-devtalles-600 mb-2">
+            {props.title}
+          </Card.Title>
+          <p className="text-3xl mb-0.5">
+            {props.participants.length} Participante
+            {props.participants.length > 1 && "s"}
+          </p>
+          {props.maxParticipants && (
+            <span className="text-devtalles-600">
+              Maximo de participantes: {props.maxParticipants}
+            </span>
+          )}
+          <DrawStatus status={props.status} />
+        </Card.Body>
+        <Card.Actions className="justify-end p-4 px-8">
+          <p className="text-gray-300">
+            Creado <DateFormatter date={props.createdAt} />
+          </p>
+        </Card.Actions>
+      </Card>
+    </article>
+  );
+}
+
+interface DrawStatusProps {
+  status: DrawStatus;
+}
+function DrawStatus({ status }: DrawStatusProps) {
+  if (status === "pending") {
+    return <span className="text-yellow-500">Próximo</span>;
+  }
+  if (status === "live") {
+    return <span className="text-green-500">En vivo</span>;
+  }
+  if (status === "finished") {
+    return <span className="text-devtalles-300">Finalizado</span>;
+  }
+  if (status === "canceled") {
+    return <span className="text-red-500">Cancelado</span>;
+  }
+}

--- a/src/views/pages/components/index.ts
+++ b/src/views/pages/components/index.ts
@@ -1,0 +1,3 @@
+export { DateFormatter } from "./DateFormatter";
+export { DrawCard } from "./DrawCard";
+export { CardSkeleton } from "./skeletons/CardSkeleton";

--- a/src/views/pages/components/skeletons/CardSkeleton.tsx
+++ b/src/views/pages/components/skeletons/CardSkeleton.tsx
@@ -1,0 +1,7 @@
+import { Card } from "react-daisyui";
+
+export function CardSkeleton() {
+  return (
+    <Card className="w-full h-52 bg-gray-300 shadow-md skeleton-animation"></Card>
+  );
+}

--- a/src/views/pages/index.ts
+++ b/src/views/pages/index.ts
@@ -1,3 +1,6 @@
+
 export { default as LoginPage } from './auth/LoginPage';
 export { default as MiddlewarePage } from './middleware/MiddlewarePage';
 export { default as DashboardPage } from './dashboard/DashboardPage';
+
+export { default as UserDashboardPage } from './user-discord/UserDashboardPage';

--- a/src/views/pages/middleware/MiddlewarePage.tsx
+++ b/src/views/pages/middleware/MiddlewarePage.tsx
@@ -9,31 +9,40 @@ const MiddlewarePage: FC = () => {
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const isFetching = useRef(false);
+
+  const token = useAuthStore((state) => state.token);
   const setUserData = useAuthStore((state) => state.setUserData);
 
   const getUserToken = useCallback(async (code: string) => {
-    try {
       const { token, user } = await AuthService.checkDiscordAthStatus(code);
       if (!token || !user) {
         throw new Error('Unable to authenticate');
       }
       setUserData(token, user);
-      navigate(`/${ROUTES.USER_DASHBOARD}`, { replace: true });
-    }
-    catch (error) {
-      console.log(error);
-      navigate(`${ROUTES.LOGIN}`, { replace: true });
-    }
+      navigate(`${ROUTES.USER_DASHBOARD}`, { replace: true });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
-    if (isFetching.current) return;
-    isFetching.current = true;
+    if (token) {
+      navigate(`${ROUTES.USER_DASHBOARD}`, { replace: true });
+      return;
+    }
     const authCode = searchParams.get('code');
-    getUserToken(authCode || '');
+    try {
+      if (!authCode) throw new Error("Code not provided")
+  
+      if (isFetching.current) return;
+      isFetching.current = true;
+      
+      getUserToken(authCode);
+      
+    } catch (error) {
+      console.log(error);
+      navigate(`${ROUTES.LOGIN}`, { replace: true });
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [getUserToken]);
+  }, [getUserToken, token]);
 
   return (
     <div className="mx-auto flex h-screen flex-row justify-center items-center">

--- a/src/views/pages/user-discord/UserDashboardPage.tsx
+++ b/src/views/pages/user-discord/UserDashboardPage.tsx
@@ -1,0 +1,35 @@
+import { FC } from "react";
+import { useGetDraws } from "../../../hooks";
+import { CardSkeleton, DrawCard } from "../components";
+
+import EmptyLogo from "../../assets/death.png";
+
+const UserDashboardPage: FC = () => {
+  const { draws, isLoading, getDraws: _getDraws } = useGetDraws();
+  if (!isLoading && draws.length === 0) {
+    return (
+      <div className="flex flex-col items-center mt-72">
+        <h3 className="text-gray-400 font-semibold text-3xl">
+          Aún no hay sorteos programados
+        </h3>
+        <img
+          className="w-40 h-auto mt-6 opacity-35"
+          src={EmptyLogo}
+          alt="No hay sorteos"
+        />
+      </div>
+    );
+  }
+  // TODO: Draw info Modal (Option to subscribe and option to open)
+  return (
+    <div className="grid grid-cols-3 gap-4 mt-20">
+      {isLoading
+        ? Array(6)
+            .fill(0)
+            .map((_, index) => <CardSkeleton key={index} />)
+        : draws.map((draw) => <DrawCard key={draw.id} {...draw} />)}
+    </div>
+  );
+};
+
+export default UserDashboardPage;


### PR DESCRIPTION
Se añadió lo siguiente:

- Un servicio para los fetch acerca de los sorteos (draws.service.ts)
- Un custom hook para obtener la respuesta del servicio del servicio de sorteos
- Componentes para mostrar la informacion del sorteo en el dashboard del usuario
- Estilos de un skeleton animado y un componente para skeleton cards
- Estructura del dashboard de los usuarios de discord consumiendo la api para mostrar los sorteos existentes 
- Ajuste en el middleware de autenticacion de usuarios de discord para redirigir a la nueva ruta establecida